### PR TITLE
Fontli-android28: Remove device token of previous user once other user sign in from the same device

### DIFF
--- a/app/models/api_session.rb
+++ b/app/models/api_session.rb
@@ -30,7 +30,7 @@ class ApiSession
     self.expires_at = current_time
     
     if self.save
-      user.update_attribute(:iphone_token, nil)
+      user.update_attributes(iphone_token: nil, android_registration_id: nil)
     else
       [nil, :unable_to_save]
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,7 @@ class User
   before_save :set_hashed_password
   after_save :save_avatar_to_file, :save_thumbnail
   after_destroy :delete_file
+  after_save :update_device_token, if: lambda { |user| user.iphone_token_changed? || user.android_registration_id_changed? }
 
   default_scope where(:active => true, :user_flags_count.lt => ALLOWED_FLAGS_COUNT)
   scope :non_admins, where(:admin => false)
@@ -730,5 +731,9 @@ private
   def recent_photos
     self.photos.limit(8).to_a
   end
-
+  
+  def update_device_token
+    User.where(:id.ne => id, :android_registration_id => android_registration_id).update_all(:android_registration_id => nil) if android_registration_id_changed?
+    User.where(:id.ne => id, :iphone_token => iphone_token).update_all(:iphone_token => nil) if iphone_token_changed?
+  end
 end

--- a/test/models/api_session_test.rb
+++ b/test/models/api_session_test.rb
@@ -43,18 +43,32 @@ describe ApiSession do
   end
 
   describe '#deactivate' do
+    let(:android_user_session) { create(:api_session, user: create(:user, android_registration_id: SecureRandom.hex(6))) }
+    let(:iphone_user_session)  { create(:api_session, user: create(:user, iphone_token: SecureRandom.hex(6))) }
+    
     it 'should set the auth_token to nil' do
       active_session.deactivate
-      active_session.auth_token.must_be_nil
+      active_session.reload.auth_token.must_be_nil
     end
 
-    it 'should return nil if session is not deactivated' do
+    it 'should not remove auth_token if session is not deactivated' do
       active_session.device_id = nil
       active_session.save(validate: false)
       active_session.deactivate
+      active_session.reload.auth_token.wont_be_nil
+    end
+    
+    it 'should set the iphone_token to nil' do
+      iphone_user_session.deactivate
+      iphone_user_session.user.reload.iphone_token.must_be_nil
+    end
+    
+    it 'should set the android_registration_id to nil' do
+      android_user_session.deactivate
+      android_user_session.user.reload.android_registration_id.must_be_nil
     end
   end
-
+  
   describe '#active?' do
     it 'should return true' do
       active_session.active?.must_equal true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -102,10 +102,25 @@ describe User do
     end
 
     describe 'after_save' do
+      let(:android_user) { create(:user, android_registration_id: SecureRandom.hex(6)) }
+      let(:iphone_user)  { create(:user, iphone_token: SecureRandom.hex(6)) }
+      
       it 'should set avatar' do
         new_user.avatar = photo_data
         new_user.save
         new_user.url.wont_be_nil
+      end
+
+      it 'should remove the iphone_token of previous user if the token is used by other user' do
+        new_user.iphone_token = iphone_user.iphone_token 
+        new_user.save
+        iphone_user.reload.iphone_token.must_be_nil
+      end
+
+      it 'should remove the android_registration_id of previous user if the device_id is used by other user' do
+        new_user.android_registration_id = android_user.android_registration_id 
+        new_user.save
+        android_user.reload.android_registration_id.must_be_nil
       end
     end
 


### PR DESCRIPTION
https://gitlab.pramati.com/Fontli/fontli-android/issues/28

The iphone_token and android_registration_id should be set as nil for previous user once other user login from the same device.
Also, Remove the device_id once the user sign out from the app.